### PR TITLE
Enhance Wart Dapp with macOS (arm64/x86_64) Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,124 +1,32 @@
 name: Release
 on:
-  push:
-    branches:
-      - master
-      - macos-arm64
-  workflow_dispatch:
+    push:
+        branches:
+            - master
+    workflow_dispatch:
 
 jobs:
-  build-ubuntu:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+        - name: Checkout
+          uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v1
 
-      - name: Docker Build
-        run: |
-          DOCKER_BUILDKIT=1 docker build . -f dockerfiles/Dockerfile --output build
+        - name: Docker Build
+          run: DOCKER_BUILDKIT=1 docker build . -f dockerfiles/Dockerfile --output build
 
-      - name: Get version
-        id: get_version
-        run: |
-          echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV 
+        - name: Get version
+          id: get_version
+          run: | 
+              echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV 
 
-      - name: Upload Ubuntu build artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ubuntu-build
-          path: ./build/wart-dapp-ubuntu22
-
-  build-macos:
-    runs-on: macos-latest
-    needs: build-ubuntu
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Rosetta 2
-        run: |
-          softwareupdate --install-rosetta --agree-to-license
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          # setup-python will automatically detect architecture, ensuring ARM64
-
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
-          brew install create-dmg
-          arch -arm64 brew install openssl@3
-
-      - name: Build for ARM
-        env:
-          ARCHFLAGS: "-arch arm64"
-          LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
-          CPPFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
-          OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
-        run: |
-          # Building ARM version
-          python3 -m PyInstaller main-arm64.spec --distpath dist-arm64 --workpath build-arm64 --clean
-          
-          mkdir dist/
-          # Rename the generated .app
-          mv dist-arm64/wart-dapp.app dist/wart-dapp-arm64.app
-
-      - name: Create DMG
-        run: |
-          mkdir -p dist/dmg
-          create-dmg \
-            --volname "wart-dapp-macos-arm64" \
-            --window-pos 200 120 \
-            --window-size 800 400 \
-            --icon-size 100 \
-            --app-drop-link 600 185 \
-            "dist/dmg/wart-dapp-macos-arm64.dmg" \
-            "dist/wart-dapp-arm64.app"
-      
-      - name: Upload Mac build artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: macos-build-arm64
-          path: 'dist/dmg/wart-dapp-macos-arm64.dmg'
-
-  release:
-    needs: [build-ubuntu, build-macos]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      
-      - name: Get version
-        id: get_version
-        run: |
-          echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV 
-
-      - name: Download Ubuntu build artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: ubuntu-build
-          path: ./build
-
-      - name: Download Mac build artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: macos-build-arm64
-          path: ./dist/dmg
-
-      - name: Release
-        uses: softprops/action-gh-release@v0.1.15
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ env.VERSION }}
-          name: Release v${{ env.VERSION }}
-          generate_release_notes: true
-          files: |
-            ./build/wart-dapp-ubuntu22
-            ./dist/dmg/wart-dapp-macos-arm64.dmg
+        - name: Release
+          uses: softprops/action-gh-release@v0.1.15
+          with:
+            tag_name: ${{ env.VERSION }}
+            generate_release_notes: true
+            files: |
+                ./build/wart-dapp-ubuntu22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,13 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt
           brew install create-dmg
+          brew install openssl@3
 
       - name: Build for ARM
         env:
           ARCHFLAGS: "-arch arm64"
+          LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
+          CPPFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
         run: |
           # Building ARM version
           python3 -m PyInstaller main-arm64.spec --distpath dist-arm64 --workpath build-arm64 --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,120 @@
 name: Release
 on:
-    push:
-        branches:
-            - master
-    workflow_dispatch:
+  push:
+    branches:
+      - master
+      - macos-arm64
+  workflow_dispatch:
 
 jobs:
-  build:
+  build-ubuntu:
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-        - name: Docker Build
-          run: DOCKER_BUILDKIT=1 docker build . -f dockerfiles/Dockerfile --output build
+      - name: Docker Build
+        run: |
+          DOCKER_BUILDKIT=1 docker build . -f dockerfiles/Dockerfile --output build
 
-        - name: Get version
-          id: get_version
-          run: | 
-              echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV 
+      - name: Get version
+        id: get_version
+        run: |
+          echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV 
 
-        - name: Release
-          uses: softprops/action-gh-release@v0.1.15
-          with:
-            tag_name: ${{ env.VERSION }}
-            generate_release_notes: true
-            files: |
-                ./build/wart-dapp-ubuntu22
+      - name: Upload Ubuntu build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ubuntu-build
+          path: ./build/wart-dapp-ubuntu22
+
+  build-macos:
+    runs-on: macos-latest
+    needs: build-ubuntu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rosetta 2
+        run: |
+          softwareupdate --install-rosetta --agree-to-license
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          # setup-python will automatically detect architecture, ensuring ARM64
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+          brew install create-dmg
+
+      - name: Build for ARM
+        env:
+          ARCHFLAGS: "-arch arm64"
+        run: |
+          # Building ARM version
+          python3 -m PyInstaller main-arm64.spec --distpath dist-arm64 --workpath build-arm64 --clean
+          
+          mkdir dist/
+          # Rename the generated .app
+          mv dist-arm64/wart-dapp.app dist/wart-dapp-arm64.app
+
+      - name: Create DMG
+        run: |
+          mkdir -p dist/dmg
+          create-dmg \
+            --volname "wart-dapp-macos-arm64" \
+            --window-pos 200 120 \
+            --window-size 800 400 \
+            --icon-size 100 \
+            --app-drop-link 600 185 \
+            "dist/dmg/wart-dapp-macos-arm64.dmg" \
+            "dist/wart-dapp-arm64.app"
+      
+      - name: Upload Mac build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-build-arm64
+          path: 'dist/dmg/wart-dapp-macos-arm64.dmg'
+
+  release:
+    needs: [build-ubuntu, build-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Get version
+        id: get_version
+        run: |
+          echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV 
+
+      - name: Download Ubuntu build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ubuntu-build
+          path: ./build
+
+      - name: Download Mac build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: macos-build-arm64
+          path: ./dist/dmg
+
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: Release v${{ env.VERSION }}
+          generate_release_notes: true
+          files: |
+            ./build/wart-dapp-ubuntu22
+            ./dist/dmg/wart-dapp-macos-arm64.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,14 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt
           brew install create-dmg
-          brew install openssl@3
+          arch -arm64 brew install openssl@3
 
       - name: Build for ARM
         env:
           ARCHFLAGS: "-arch arm64"
           LDFLAGS: "-L/opt/homebrew/opt/openssl@3/lib"
           CPPFLAGS: "-I/opt/homebrew/opt/openssl@3/include"
+          OPENSSL_ROOT_DIR: "/opt/homebrew/opt/openssl@3"
         run: |
           # Building ARM version
           python3 -m PyInstaller main-arm64.spec --distpath dist-arm64 --workpath build-arm64 --clean

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/
 __pycache__
 wartwallet.db
 .idea/
+wart-py310/
+dist/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__
 wartwallet.db
 .idea/
 wart-py310/
+wart-py39/
 dist/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -21,6 +21,4 @@ python -m PyInstaller main-arm64.spec
 http://62.72.44.89:3001 # blu & Asia
 
 deactivate
-
-
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # wart-dapp
+
+
+## Build on MacOS (Arm64)
+```shell
+brew install python@3.10
+
+python3.10 -m venv wart-py310
+
+source wart-py310/bin/activate
+
+python -m pip install -r requirements.txt
+
+rm -rf build dist
+
+python -m PyInstaller main-arm64.spec
+
+./dist/wart-dapp/wart-dapp
+
+# you could use this node (from https://github.com/warthog-network/public-nodes/blob/master/nodes.txt)
+http://62.72.44.89:3001 # blu & Asia
+
+deactivate
+
+
+```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,35 @@ source wart-py310/bin/activate
 
 python -m pip install -r requirements.txt
 
+brew install openssl@3
+
 rm -rf build dist
 
 python -m PyInstaller main-arm64.spec
+
+./dist/wart-dapp/wart-dapp
+
+# you could use this node (from https://github.com/warthog-network/public-nodes/blob/master/nodes.txt)
+http://62.72.44.89:3001 # blu & Asia
+
+deactivate
+```
+
+## Build on MacOS (x86_64)
+```shell
+brew install python@3.9
+
+python3.9 -m venv wart-py39
+
+source wart-py39/bin/activate
+
+python -m pip install -r requirements.txt
+
+brew install openssl@3
+
+rm -rf build dist
+
+python -m PyInstaller main-x86_64.spec
 
 ./dist/wart-dapp/wart-dapp
 

--- a/main-arm64.spec
+++ b/main-arm64.spec
@@ -1,0 +1,62 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='wart-dapp',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=True,
+    target_arch='arm64',
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='wart-dapp'
+)
+
+app = BUNDLE(
+    coll,
+    name='wart-dapp.app',
+    icon=None,
+    bundle_identifier='com.wart.dapp',
+    info_plist={
+        'CFBundleName': 'Wart DApp',
+        'CFBundleDisplayName': 'Wart DApp',
+        'CFBundleExecutable': 'wart-dapp',
+        'CFBundlePackageType': 'APPL',
+        'CFBundleShortVersionString': '1.0.0',
+        'NSHighResolutionCapable': True,
+        'LSBackgroundOnly': False,
+        'LSMinimumSystemVersion': '10.15',
+    }
+)

--- a/main-arm64.spec
+++ b/main-arm64.spec
@@ -5,9 +5,12 @@ block_cipher = None
 a = Analysis(
     ['main.py'],
     pathex=['.'],
-    binaries=[],
+    binaries=[
+        ('/opt/homebrew/opt/openssl/lib/libcrypto.dylib', '.'),
+        ('/opt/homebrew/opt/openssl/lib/libssl.dylib', '.')
+    ],
     datas=[],
-    hiddenimports=[],
+    hiddenimports=['pycoin'],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/main-arm64.spec
+++ b/main-arm64.spec
@@ -6,8 +6,8 @@ a = Analysis(
     ['main.py'],
     pathex=['.'],
     binaries=[
-        ('/opt/homebrew/opt/openssl/lib/libcrypto.dylib', '.'),
-        ('/opt/homebrew/opt/openssl/lib/libssl.dylib', '.')
+        ('/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib', '.'),
+        ('/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib', '.')
     ],
     datas=[],
     hiddenimports=['pycoin'],

--- a/main-arm64.spec
+++ b/main-arm64.spec
@@ -10,7 +10,7 @@ a = Analysis(
         ('/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib', '.')
     ],
     datas=[],
-    hiddenimports=['pycoin'],
+    hiddenimports=['pycoin', 'pyperclip'],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/main-x86_64.spec
+++ b/main-x86_64.spec
@@ -1,0 +1,65 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=['.'],
+    binaries=[
+        ('/usr/local/opt/openssl@3/lib/libcrypto.3.dylib', '.'),
+        ('/usr/local/opt/openssl@3/lib/libssl.3.dylib', '.')
+    ],
+    datas=[],
+    hiddenimports=['pycoin', 'pyperclip'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='wart-dapp',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=True,
+    target_arch='x86_64',
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='wart-dapp'
+)
+
+app = BUNDLE(
+    coll,
+    name='wart-dapp.app',
+    icon=None,
+    bundle_identifier='com.wart.dapp',
+    info_plist={
+        'CFBundleName': 'Wart DApp',
+        'CFBundleDisplayName': 'Wart DApp',
+        'CFBundleExecutable': 'wart-dapp',
+        'CFBundlePackageType': 'APPL',
+        'CFBundleShortVersionString': '1.0.0',
+        'NSHighResolutionCapable': True,
+        'LSBackgroundOnly': False,
+        'LSMinimumSystemVersion': '10.15',
+    }
+)

--- a/mainwindow.py
+++ b/mainwindow.py
@@ -25,9 +25,9 @@ class Ui_MainWindow_Wart(object):
     def setupUi(self, MainWindow):
         if not MainWindow.objectName():
             MainWindow.setObjectName(u"MainWindow")
-        MainWindow.resize(1000, 696)
-        MainWindow.setMinimumSize(QSize(1000, 600))
-        MainWindow.setMaximumSize(QSize(1000, 696))
+        MainWindow.resize(1300, 696)
+        MainWindow.setMinimumSize(QSize(1300, 600))
+        MainWindow.setMaximumSize(QSize(1300, 696))
         icon = QIcon()
         icon.addFile(u":/icon/icons/icon.ico", QSize(), QIcon.Normal, QIcon.Off)
         MainWindow.setWindowIcon(icon)
@@ -772,4 +772,3 @@ class Ui_MainWindow_Wart(object):
         self.label_7.setText(QCoreApplication.translate("MainWindow", u".", None))
         self.balance.setText("")
     # retranslateUi
-

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,19 +6,19 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
+    <width>1300</width>
     <height>696</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>1000</width>
+    <width>1300</width>
     <height>600</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>1000</width>
+    <width>1300</width>
     <height>696</height>
    </size>
   </property>


### PR DESCRIPTION
Hello @I-luk-I ,

I tried to build the dmg file for wart dapp via GitHub Action and tested it on my Macbook Pro (x86_64) and Mac Mini (arm64). However, I found that because the dmg file build process must require an apple developer authentication signature to run securely on both of my machines. If we can't get Apple developer signatures, then it seems impractical to use the dmg format to distribute the wart dapp.

To resolve this, I have incorporated support for macOS (arm64/x86_64) users to run the Wart Dapp using a Python virtual environment. I have created a `main-arm64.spec` file, a `main-x86_64.spec` file, and updated the `README.md` to guide Mac users through the process of setting up and running the Wart Dapp within a Python virtual environment. Additionally, I adjusted the width of the main window from 1000 to 1300, and the main windows now displays correctly (on my Mac Mini and Macbook Pro).

Changes:
main-arm64.spec: Added a specification file for macOS (arm64) to facilitate the setup of the Python virtual environment.

main-x86_64.spec: Added a specification file for macOS (x86_64) to facilitate the setup of the Python virtual environment.

README.md: Updated the documentation to include instructions for macOS (arm64/x86_64) users on how to install and run the Wart Dapp using a Python virtual environment.

This PR provides a temporary solution for macOS (arm64/x86_64) users to run the Wart Dapp. Please review the changes and let me know if there are any further adjustments needed.